### PR TITLE
float removed from hamburger items

### DIFF
--- a/css/partials/_menu.scss
+++ b/css/partials/_menu.scss
@@ -144,7 +144,6 @@ $transition-delay: 0.05s;
 .nav-item {
     position: relative;
     display: inline-block;
-    float: left;
     clear: both;
     color: transparent;
     font-size: 1.2em;


### PR DESCRIPTION
The float shouldn't do anything because it gets overruled by other css. I'm having trouble with grunt, so I'll double check later.